### PR TITLE
Properly animates depending on wintype animation property in config

### DIFF
--- a/src/picom.c
+++ b/src/picom.c
@@ -1051,7 +1051,7 @@ paint_preprocess(session_t *ps, bool *fade_running, bool *animation_running) {
 				}
 
 			// Submit window size change
-			if (size_changed) {
+			if (size_changed && w->state != WSTATE_UNMAPPED && w->state != WSTATE_DESTROYING && w->state != WSTATE_UNMAPPING) {
 				win_on_win_size_change(ps, w);
 
 				pixman_region32_clear(&w->bounding_shape);

--- a/src/win.c
+++ b/src/win.c
@@ -484,18 +484,19 @@ static void init_animation(session_t *ps, struct managed_win *w) {
 	}
 	static double *anim_x, *anim_y, *anim_w, *anim_h;
 	enum open_window_animation animation;
-	if (ps->o.wintype_option[w->window_type].animation != OPEN_WINDOW_ANIMATION_INVALID
-		&& !w->dwm_mask) {
-		animation = ps->o.wintype_option[w->window_type].animation;
-	}
-	else
-		animation = ps->o.animation_for_open_window;
+
+	
+	animation = ps->o.animation_for_open_window;
 
 	if (w->window_type != WINTYPE_TOOLTIP &&
 		wid_has_prop(ps, w->client_win, ps->atoms->aWM_TRANSIENT_FOR)) {
 		animation = ps->o.animation_for_transient_window;
 	}
 
+	if (ps->o.wintype_option[w->window_type].animation != OPEN_WINDOW_ANIMATION_INVALID
+		&& !w->dwm_mask) {
+		animation = ps->o.wintype_option[w->window_type].animation;
+	}
 
 	anim_x = &w->animation_center_x, anim_y = &w->animation_center_y;
 	anim_w = &w->animation_w, anim_h = &w->animation_h;


### PR DESCRIPTION
Currently picom ignores animation type overrides that are set under the wintype section of the config and this PR fixes it