### PR TITLE
Add 'animation-exclude' to command line options (picom_options[])

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -192,7 +192,10 @@ static const struct picom_option picom_options[] = {
     {"animation-clamping"          , no_argument      , 809, NULL          , "Enable/disable animation clamping. Disabling increases performance"},
     {"animation-for-open-window"   , required_argument, 810, NULL          , "Set animation for opening window (Check sample.conf for options)."},
     {"animation-for-transient-window", required_argument, 811, NULL        , "Set animation for transient (child) windows."},
-    {"animation-exclude"           , required_argument, 812, NULL          , "Specify a list of conditions of windows that should never be animated."},
+    {"animation-for-unmap-window"  , required_argument, 812, NULL          , "Set animation for unmap window (Check sample.conf for options)."},
+    {"animation-for-next-tag"      , required_argument, 813, NULL          , "Set animation for next tag (Check sample.conf for options)."},
+    {"animation-for-prev-tag"      , required_argument, 814, NULL          , "Set animation for previous tag (Check sample.conf for options)."},
+    {"animation-exclude"           , required_argument, 820, NULL          , "Specify a list of conditions of windows that should never be animated."},
 
 };
 // clang-format on
@@ -803,6 +806,36 @@ bool get_cfg(options_t *opt, int argc, char *const *argv, bool shadow_enable,
 			break;
 		}
 		case 812: {
+			// --animation-for-unmap-window
+			enum open_window_animation animation = parse_open_window_animation(optarg);
+			if (animation >= OPEN_WINDOW_ANIMATION_INVALID) {
+				log_warn("Invalid unmap-window animation %s, ignoring.", optarg);
+			} else {
+				opt->animation_for_unmap_window = animation;
+			}
+			break;
+		}
+		case 813: {
+			// --animation-for-next-tag
+			enum open_window_animation animation = parse_open_window_animation(optarg);
+			if (animation >= OPEN_WINDOW_ANIMATION_INVALID) {
+				log_warn("Invalid next-tag animation %s, ignoring.", optarg);
+			} else {
+				opt->animation_for_next_tag = animation;
+			}
+			break;
+		}
+		case 814: {
+			// --animation-for-prev-tag
+			enum open_window_animation animation = parse_open_window_animation(optarg);
+			if (animation >= OPEN_WINDOW_ANIMATION_INVALID) {
+				log_warn("Invalid prev-tag animation %s, ignoring.", optarg);
+			} else {
+				opt->animation_for_prev_tag = animation;
+			}
+			break;
+		}
+		case 820: {
 			// --animation-exclude
 			condlst_add(&opt->animation_blacklist, optarg);
 			break;

--- a/src/options.c
+++ b/src/options.c
@@ -192,6 +192,7 @@ static const struct picom_option picom_options[] = {
     {"animation-clamping"          , no_argument      , 809, NULL          , "Enable/disable animation clamping. Disabling increases performance"},
     {"animation-for-open-window"   , required_argument, 810, NULL          , "Set animation for opening window (Check sample.conf for options)."},
     {"animation-for-transient-window", required_argument, 811, NULL        , "Set animation for transient (child) windows."},
+    {"animation-exclude"           , required_argument, 812, NULL          , "Specify a list of conditions of windows that should never be animated."},
 
 };
 // clang-format on

--- a/src/win.c
+++ b/src/win.c
@@ -696,9 +696,11 @@ void win_process_update_flags(session_t *ps, struct managed_win *w) {
 
         // Determine if a window should animate
 		if (win_should_animate(ps, w)) {
-			if (w->pending_g.y < 0 && w->g.y > 0 && abs(w->pending_g.y - w->g.y) >= w->pending_g.height)
+			if ((w->pending_g.y < 0 && w->g.y > 0 && abs(w->pending_g.y - w->g.y) >= w->pending_g.height) ||
+			   (w->pending_g.x < 0 && w->g.x > 0 && abs(w->pending_g.x - w->g.x) >= w->pending_g.width))
 				w->dwm_mask = ANIM_PREV_TAG;
-			else if (w->pending_g.y > 0 && w->g.y < 0 && abs(w->pending_g.y - w->g.y) >= w->pending_g.height)
+			else if ((w->pending_g.y > 0 && w->g.y < 0 && abs(w->pending_g.y - w->g.y) >= w->pending_g.height) ||
+			        (w->pending_g.x > 0 && w->g.x < 0 && abs(w->pending_g.x - w->g.x) >= w->pending_g.width))
 				w->dwm_mask = ANIM_NEXT_TAG;
 
 			if (!was_visible || w->dwm_mask) {


### PR DESCRIPTION
The processing code in `get_cfg()` was there, but `animation-exclude` was missing from `picom_options[]`.