### PR TITLE
Remove commas from lists on the sample config

### DIFF
--- a/picom.sample.conf
+++ b/picom.sample.conf
@@ -170,7 +170,7 @@ inactive-opacity-override = true;
 # Specify a list of conditions of windows that should never be considered focused.
 # focus-exclude = []
 focus-exclude = [
-"class_g = 'Cairo-clock'" ,
+"class_g = 'Cairo-clock'"
 ];
 
 # Use fixed inactive dim value, instead of adjusting according to window opacity.
@@ -210,7 +210,7 @@ blur-background-exclude = [
   "class_g = 'Discord'",
   "class_g = 'Dunst'",
   "class_g = 'Peek'",
-  "class_g *?= 'slop'",
+  "class_g *?= 'slop'"
 ];
 
 #################################
@@ -435,5 +435,5 @@ wintypes:
 opacity-rule = [
   "100:class_g = 'St' && focused",
   "50:class_g = 'St' && !focused",
-  "100:fullscreen",
+  "100:fullscreen"
 ];


### PR DESCRIPTION
Some exclude lists had an comma on the last item of the list and it was crashing when trying to start picom giving syntax error messages on those lines, this simple edit should fix it. 

